### PR TITLE
Component Heap templated arguments

### DIFF
--- a/include/component_heap.h
+++ b/include/component_heap.h
@@ -2,11 +2,16 @@
 #include <iosfwd>
 #include <iterator>
 #include <map>
+#include <typeindex>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 #include "heap_entry.h"
 #include "types.h"
+
+using ComponentMap = std::map<Entity, HeapEntry>;
+using ComponentTypeMap = std::unordered_map<std::type_index, ComponentMap>;
 
 class Heap {
   ComponentTypeMap componentTypeMap;
@@ -17,12 +22,12 @@ class Heap {
     friend Heap;
     friend auto operator<<(std::ostream& os, const Heap::iterator& iterator)
       -> std::ostream&;
-    std::vector<ComponentType> componentTypes;
+    std::vector<std::type_index> componentTypes;
     std::vector<ComponentMap::iterator> componentIterators;
     std::vector<ComponentMap*> componentMaps;
     bool atEnd;
     iterator(ComponentTypeMap* componentTypeMap,
-             const std::vector<ComponentType>& componentTypes,
+             const std::vector<std::type_index>& componentTypes,
              bool moveToEnd = false);
     static auto compareComponentIterators(const ComponentMap::iterator& lhs,
                                           const ComponentMap::iterator& rhs)
@@ -39,25 +44,48 @@ class Heap {
     // iterator traits
     using difference_type = std::ptrdiff_t;
     using value_type = std::vector<HeapEntry>;
-    using pointer = const std::vector<HeapEntry>*;
-    using reference = const std::vector<HeapEntry>&;
+    using pointer = const std::vector<HeapEntry*>;
+    using reference = const std::vector<HeapEntry&>;
     using iterator_category = std::input_iterator_tag;
   };
 
   template <typename T>
-  void insert(Entity entity, ComponentType componentType, T* heapEntry);
-  void erase(Entity entity, ComponentType componentType);
+  void insert(Entity entity, T* heapEntry);
+  template <typename T>
+  void erase(Entity entity);
   void clear();
   auto data() -> ComponentTypeMap*;
-  auto begin(const std::vector<ComponentType>& componentTypes) -> iterator;
-  auto end(const std::vector<ComponentType>& componentTypes) -> iterator;
+  template <class... Types>
+  auto begin() -> iterator;
+  template <class... Types>
+  auto end() -> iterator;
 };
 
 auto operator<<(std::ostream& os, const Heap::iterator& iterator)
   -> std::ostream&;
 
 template <typename T>
-void Heap::insert(Entity entity, ComponentType componentType, T* heapEntry) {
-  componentTypeMap[componentType][entity] =
+void Heap::insert(Entity entity, T* heapEntry) {
+  componentTypeMap[std::type_index(typeid(T))][entity] =
     HeapEntry(heapEntry, nextComponentId++);
+}
+
+template <typename T>
+void Heap::erase(Entity entity) {
+  auto itr = componentTypeMap.find(std::type_index(typeid(T)));
+  if (itr != std::end(componentTypeMap)) {
+    itr->second.erase(entity);
+  }
+}
+
+template <typename... Types>
+auto Heap::begin() -> Heap::iterator {
+  return iterator(&componentTypeMap, {std::type_index(typeid(Types))...},
+                  /*moveToEnd=*/false);
+}
+
+template <typename... Types>
+auto Heap::end() -> Heap::iterator {
+  return iterator(&componentTypeMap, {std::type_index(typeid(Types))...},
+                  /*moveToEnd=*/true);
 }

--- a/include/types.h
+++ b/include/types.h
@@ -1,11 +1,8 @@
 #pragma once
 #include <cstdint>
 #include <map>
+#include <typeindex>
 #include <unordered_map>
 
-typedef uint64_t Entity;
-using ComponentType = uint32_t;
+using Entity = uint64_t;
 using ComponentId = uint64_t;
-class HeapEntry;
-using ComponentMap = std::map<Entity, HeapEntry>;
-using ComponentTypeMap = std::unordered_map<ComponentType, ComponentMap>;

--- a/src/component_heap.cpp
+++ b/src/component_heap.cpp
@@ -1,27 +1,4 @@
 #include "component_heap.h"
 
-#include <unordered_map>
-#include <utility>
-
-void Heap::erase(Entity entity, ComponentType componentType) {
-  auto itr = componentTypeMap.find(componentType);
-  if (itr != std::end(componentTypeMap)) {
-    itr->second.erase(entity);
-  }
-}
-
 void Heap::clear() { componentTypeMap.clear(); }
-
 auto Heap::data() -> ComponentTypeMap* { return &componentTypeMap; }
-
-auto Heap::begin(const std::vector<ComponentType>& componentTypes)
-  -> Heap::iterator {
-  return iterator(&componentTypeMap, componentTypes,
-                  /*moveToEnd=*/false);
-}
-
-auto Heap::end(const std::vector<ComponentType>& componentTypes)
-  -> Heap::iterator {
-  return iterator(&componentTypeMap, componentTypes,
-                  /*moveToEnd=*/true);
-}

--- a/src/component_heap_iterator.cpp
+++ b/src/component_heap_iterator.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <iterator>
 #include <map>
+#include <typeindex>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -12,7 +13,7 @@
 class HeapEntry;
 
 Heap::iterator::iterator(ComponentTypeMap* componentTypeMap,
-                         const std::vector<ComponentType>& componentTypes,
+                         const std::vector<std::type_index>& componentTypes,
                          bool moveToEnd)
   : componentTypes(componentTypes), atEnd(moveToEnd) {
   if (atEnd) {

--- a/tests/component_heap.test.cpp
+++ b/tests/component_heap.test.cpp
@@ -9,45 +9,53 @@ TEST(ComponentHeap, Insert){
   // Arrange
   Heap heap;
   Entity entity = 0;
-  ComponentType componentType = 0;
-  HeapEntry component = HeapEntry(new Type0, 0);
 
   // Act
-  heap.insert(entity, componentType, new Type0);
+  heap.insert(entity, new Type0);
+  heap.insert(entity, new Type1);
 
   // Assert
   ASSERT_EQ(
-    heap.data()->at(componentType).size(),
+    heap.data()->size(),
+    2
+  );
+  EXPECT_EQ(
+    heap.data()->at(std::type_index(typeid(Type0))).at(entity).componentId,
+    0
+  );
+    EXPECT_EQ(
+    heap.data()->at(std::type_index(typeid(Type1))).at(entity).componentId,
     1
   );
+  EXPECT_NO_THROW(heap.data()->at(std::type_index(typeid(Type0))).at(entity).to<Type0>());
 }
 
 TEST(ComponentHeap, Erase){
   // Arrange
   Heap heap;
   Entity entity = 0;
-  ComponentType componentType = 0;
-  (*heap.data())[componentType][entity] = std::move(HeapEntry(new Type0, 0));
-  (*heap.data())[componentType][entity+1] = std::move(HeapEntry(new Type0, 1));
+  std::type_index componentType = std::type_index(typeid(Type0));
+  (*heap.data())[componentType][entity] = HeapEntry(new Type0, 0);
+  (*heap.data())[componentType][entity+1] = HeapEntry(new Type0, 1);
 
   // Act
-  heap.erase(entity, componentType);
+  heap.erase<Type0>(entity);
 
   // Assert
   EXPECT_EQ(
     heap.data()->at(componentType).find(entity),
     heap.data()->at(componentType).end()
   );
-  EXPECT_NO_THROW(heap.erase(-1, -1));
+  EXPECT_NO_THROW(heap.erase<Type1>(-1));
 }
 
 TEST(ComponentHeap, Clear){
   // Arrange
   Heap heap;
   Entity entity = 0;
-  ComponentType componentType = 0;
-  (*heap.data())[componentType][entity] = std::move(HeapEntry(new Type0, 0));
-  (*heap.data())[componentType][entity+1] = std::move(HeapEntry(new Type0, 1));
+  std::type_index componentType = std::type_index(typeid(Type0));
+  (*heap.data())[componentType][entity] = HeapEntry(new Type0, 0);
+  (*heap.data())[componentType][entity+1] = HeapEntry(new Type0, 1);
 
   // Act
   heap.clear();


### PR DESCRIPTION
* Updated Component Heap's interface to use templated arguments instead of a "ComponentType" type. 
* The internal map for types now uses type_index from the standard library to provide indexing.
* Updated Relevant tests.